### PR TITLE
Add custom titan ready message

### DIFF
--- a/Moblin.Archon/mod/scripts/vscripts/archon_TitanFrameworkInit.nut
+++ b/Moblin.Archon/mod/scripts/vscripts/archon_TitanFrameworkInit.nut
@@ -14,6 +14,7 @@ void function ArchonUIInit()
 		Archon.BaseName = "ion"
 		Archon.altChassisType = frameworkAltChassisMethod.NONE
 		Archon.passiveDisplayNameOverride = "#TITAN_ARCHON_PASSIVE_TITLE"
+		Archon.titanReadyMessageOverride = "#HUD_ARCHON_READY"
 		Archon.difficulty = 2
 		Archon.speedStat = 2
 		Archon.damageStat = 3


### PR DESCRIPTION
Replaces the generic "TITAN READY" message from titan framework with the one found in this mod's localization file.

Before:
![Screenshot 2024-09-07 135135](https://github.com/user-attachments/assets/9367aebd-3029-4ef4-9b87-be9b3a425ad0)

After:
![Screenshot 2024-09-07 134524](https://github.com/user-attachments/assets/7b2bb8be-fb93-4d4f-8a1d-2a9f98f5fefa)

(The custom "press v for titanfall" message is not part of this pr, i just forgot to disable my own custom text mod)
